### PR TITLE
check to see if wishlist items are in cart and update data accordingly

### DIFF
--- a/src/sites/barnesNNoble/helpers/wishlistItem.ts
+++ b/src/sites/barnesNNoble/helpers/wishlistItem.ts
@@ -28,7 +28,10 @@ const buildWishlistItems = async ( page: Page ): Promise<WishlistItem[]> => {
       const dateAddedElement = (await wishlist.$eval(selectors.wishlistAddedDate, (node) => (node as HTMLDivElement).innerText)).split(" ")[1];
       const currPrice = (await wishlist.$eval(selectors.currPrice, (node) => (node as HTMLSpanElement).innerText)).slice(1);
       const imgSrc = await wishlist.$eval(selectors.itemImg, (node) => (node as HTMLImageElement).currentSrc);
-      const addToCartBtn= await wishlist.$(selectors.cartBtn);
+      const inCartSpan = await wishlist.$(selectors.inCartSpan);
+      // TODO handle PRE-ORDER btn
+      // const addToCartBtn = await wishlist.$(selectors.cartBtn);
+
       const earliestDeliveryText = await wishlist.$eval(selectors.earliestDeliverySpan, (node) => (node as HTMLSpanElement).innerText);
       const outOfStock = await wishlist.$eval(selectors.outOfStockSpan, (node) => (node as HTMLSpanElement).innerText.includes("Temporarily out of stock online"))
 
@@ -40,9 +43,8 @@ const buildWishlistItems = async ( page: Page ): Promise<WishlistItem[]> => {
       dateAdded: dateAddedElement,
       currentPrice: Number(currPrice),
       productImageUrl: imgSrc,
-      inCart: addToCartBtn ? false : true,
+      inCart: inCartSpan ? true : false,
       earliestDeliveryDate: earliestDeliveryText ? earliestDeliveryText : "",
-      // TODO sort out when an item is unavailable
       isAvailable: outOfStock ? false : true,
     });
   }

--- a/src/sites/barnesNNoble/references.ts
+++ b/src/sites/barnesNNoble/references.ts
@@ -19,13 +19,13 @@ const selectors = {
   "earliestDeliverySpan": "span.bold-text",
   "wishlistArray": "div.prod-img-details-sec",
   "outOfStockSpan": "div.pdp-commerce-zone > p > span",
+  "inCartSpan": "div.wishlist-icons > span"
 };
 
 const xpaths = {
   "signInBtn": '//a[contains(., "Sign In")]',
   "loggedInText": '//a[contains(text(), "Hi, ")]',
   "wishlistLandingText": '//h2[contains(., "My Wishlist")]',
-  // "outOfStockSpan": '//span[contains(., "Temporarily out of stock online")]',
 }
 
 const urls = {


### PR DESCRIPTION
check to see if wishlist items are in the cart and update data accordingly.

Was previously checking for the presence of `Add to Cart` btn but this would cause false positives in some situations.